### PR TITLE
Updated moved package import path.

### DIFF
--- a/main.go
+++ b/main.go
@@ -22,8 +22,8 @@ import (
 	_ "github.com/lib/pq"
 	"github.com/qor/admin"
 	"github.com/qor/qor"
-	"github.com/shurcooL/go/gzip_file_server"
 	"github.com/shurcooL/httpfs/html/vfstemplate"
+	"github.com/shurcooL/httpgzip"
 )
 
 // settings holds the congo configuration.
@@ -137,8 +137,8 @@ func main() {
 	mux := http.NewServeMux()
 	Admin.MountTo("/admin", mux)
 
-	http.Handle("/assets/", gzip_file_server.New(assets))
-	fs := http.FileServer(http.Dir("bower_components"))
+	http.Handle("/assets/", httpgzip.FileServer(assets, httpgzip.FileServerOptions{}))
+	fs := httpgzip.FileServer(http.Dir("bower_components"), httpgzip.FileServerOptions{})
 	http.Handle("/bower_components/", http.StripPrefix("/bower_components", fs))
 	http.Handle("/api/", service.Mux)
 	http.HandleFunc("/", mainHandler)


### PR DESCRIPTION
The [`github.com/shurcooL/go/gzip_file_server`](https://godoc.org/github.com/shurcooL/go/gzip_file_server) package has been overhauled to have better style, and moved to import path [`github.com/shurcooL/httpgzip`](https://godoc.org/github.com/shurcooL/httpgzip).

Also use gzip file server for serving bower_components.
